### PR TITLE
Image upload form parameter fix and Spree::Product#variant_images association fix

### DIFF
--- a/app/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/controllers/spree/admin/images_controller_decorator.rb
@@ -9,6 +9,15 @@ Spree::Admin::ImagesController.class_eval do
     end
 
     def viewable_ids
+      # If viewable_ids is blank fall back to viewable_id
+      #
+      # This allows the existing drag / drop image upload form to continue to
+      # function with no additional modifications
+      #
+      if params[:image][:viewable_ids].nil? && params[:image][:viewable_id].present?
+        params[:image][:viewable_ids] = [params[:image][:viewable_id]]
+      end
+
       params[:image][:viewable_ids].reject(&:blank?)
     end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,5 +1,5 @@
 Spree::Product.class_eval do
-  has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_images, through: :variants_including_master
+  has_many :nonuniq_variant_images, -> { order(:position) }, source: :variant_image_images, through: :variants_including_master
 
   def variant_images
     nonuniq_variant_images.distinct

--- a/spec/models/spree/product_decorator_spec.rb
+++ b/spec/models/spree/product_decorator_spec.rb
@@ -15,6 +15,7 @@ describe Spree::Product do
   describe '#variant_images' do
     it 'returns unique list of variant images' do
       expect(product.reload.variant_images.size).to eq(2)
+      expect(product.reload.variant_images).to include(image_blue, image_green)
     end
   end
 


### PR DESCRIPTION
Howdy!

This PR addresses two different problems, one I encountered when trying to use the latest released version of this gem (1.0.2), and the other while trying to fix that problem based on the master branch.

## Problem, the First:

![screen shot 2017-09-19 at 3 42 47 pm](https://user-images.githubusercontent.com/40662/30612010-3921348a-9d51-11e7-83bc-ae777284e884.png)

When using the image drag / drop upload form in Solidus (pictured above), the `image[:viewable_ids]` isn't sent to the server so [app/controllers/spree/admin/images_controller_decorator](https://github.com/solidusio/solidus_asset_variant_options/blob/master/app/controllers/spree/admin/images_controller_decorator.rb#L12) threw an error causing the image upload to fail. Defacing the form in `views/spree/admin/images/index` doesn't fix the problem because the upload is handled by a bit of javascript. So trying to keep the integration lightweight and as unobtrusive as possible I added a check to the `images_controller_decorator` which sets the proper param if it is missing.

## Problem, the Second:

The recent changes to support Rails 5.1 incorrectly set the `source` association on `Spree::Products` to `variant_images` rather than `variant_image_images`. That changed the behavior of `Spree::Product#variant_images` which started returning `Spree::VariantImage` records where previously `Spree::Image` records were returned.

---

Normally I'd submit two requests for these fixes, but since I stumbled onto the second problem while working on the first one they got all mashed up. If you would like I can pull them apart, or if you are ok working on them in parallel I am happy to make any changes.

Of course let me know if you have any questions. 🚒 