### PR TITLE
Make it work with ProductGallery, image_row partial and API, add sort method

### DIFF
--- a/app/decorators/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/admin/images_controller_decorator.rb
@@ -10,11 +10,17 @@ module Spree
       private
 
       def set_variants
-        @image.variant_ids = viewable_ids
+        if params[:image][:viewable_ids].present? &&
+           params[:image][:viewable_ids].reject(&:blank?).present?
+          @image.variant_ids = params[:image][:viewable_ids].reject(&:blank?)
+        else #use master variant as falback when empty
+          @image.variant_ids = [@product.master.id]
+        end
       end
 
-      def viewable_ids
-        params[:image][:viewable_ids].reject(&:blank?)
+      def set_viewable # viewable remains first variant
+        @image.viewable_type = 'Spree::Variant'
+        @image.viewable_id = @image.variant_ids.first
       end
 
       ::Spree::Admin::ImagesController.prepend self

--- a/app/decorators/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/admin/images_controller_decorator.rb
@@ -7,6 +7,24 @@ module Spree
         base.before_action :set_variants, only: %i[create update]
       end
 
+      # update variant image positions the same way like image positions
+      # TODO: find more meaningful way to use variant image positions when showing images
+      def update_positions
+        ActiveRecord::Base.transaction do
+          params[:positions].each do |id, index|
+            img = Spree::Image.find(id)
+            img.set_list_position(index)
+            img.variant_images.each do |vi|
+              vi.update_attribute(:position, index)
+            end
+          end
+        end
+
+        respond_to do |format|
+          format.js { head :no_content }
+        end
+      end
+
       private
 
       def set_variants

--- a/app/decorators/controllers/spree/api/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/api/images_controller_decorator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Spree
+  module Api
+    module ImagesControllerDecorator
+      def self.prepended(base)
+        base.after_action :set_variants, only: %i[create update]
+      end
+
+      private
+
+      def set_variants
+        if params[:image][:viewable_ids].present? &&
+           params[:image][:viewable_ids].reject(&:blank?).present?
+          @image.variant_ids = params[:image][:viewable_ids].reject(&:blank?)
+        else #use master variant as falback when empty
+          @image.variant_ids = [@product.master.id]
+        end
+        # reset normal viewable
+        @image.viewable_type = 'Spree::Variant'
+        @image.viewable_id = @image.variant_ids.first
+      end
+
+      ::Spree::Api::ImagesController.prepend self
+    end
+  end
+end

--- a/app/decorators/models/spree/gallery/product_gallery_decorator.rb
+++ b/app/decorators/models/spree/gallery/product_gallery_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  module Gallery
+    module ProductGalleryDecorator
+      attr_accessor :viewable_ids
+
+      def self.prepended(base)
+        def images
+          @images ||= @product.variant_images.collect { |vi| vi.image }.uniq
+        end
+      end
+
+      ::Spree::Gallery::ProductGallery.prepend self
+    end
+  end
+end

--- a/app/decorators/models/spree/image_decorator.rb
+++ b/app/decorators/models/spree/image_decorator.rb
@@ -5,7 +5,7 @@ module Spree
     attr_accessor :viewable_ids
 
     def self.prepended(base)
-      base.has_many :variant_images, class_name: '::Spree::VariantImage'
+      base.has_many :variant_images, class_name: '::Spree::VariantImage', dependent: :destroy
       base.has_many :variants, through: :variant_images
     end
 

--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -6,6 +6,7 @@ module Spree
     belongs_to :image, class_name: 'Spree::Image'
     belongs_to :variant, class_name: 'Spree::Variant', touch: true
 
+    acts_as_list
     scope :with_position, -> { where("position IS NOT NULL") }
     default_scope -> { order("#{table_name}.position") }
 

--- a/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_form/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,15 +1,2 @@
 <!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
-<%= f.hidden_field :viewable_id, value: 1 %>
-<%= f.select :viewable_ids, options_for_select(@variants, @image.variant_ids), {}, {multiple: true, :class => 'select2 fullwidth'} %>
-
-<%# Keeping this script tag in the view for now.  %>
-<script>
-$('#image_viewable_ids')
-    .on('change', function() {
-        $('#image_viewable_id').val($(this).val()[0]);
-    })
-    .select2({
-        allowClear: true,
-        dropdownAutoWidth: true
-    });
-</script>
+<%= f.select :viewable_ids, options_for_select(@variants, @image.try(:variant_ids)), {}, {multiple: true, :class => 'select2 fullwidth'} %>

--- a/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,0 +1,2 @@
+<!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
+<%= f.select :viewable_ids, options_for_select(@variants, image.variant_ids), {}, {multiple: true, :class => 'select2 fullwidth'} %>

--- a/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,2 +1,4 @@
 <!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
-<%= f.select :viewable_ids, options_for_select(@variants, image.variant_ids), {}, {multiple: true, :class => 'select2 fullwidth'} %>
+<% @variants.each do |v| %>
+  <%= v[0] if image.variant_ids.include?(v[1]) %>
+<% end %>

--- a/app/overrides/spree/products/_thumbnails/replace_thumbnail_classes_with_classes_including_variant_ids.html.erb.deface
+++ b/app/overrides/spree/products/_thumbnails/replace_thumbnail_classes_with_classes_including_variant_ids.html.erb.deface
@@ -1,15 +1,15 @@
 <!-- replace '#product-thumbnails' -->
 <%# no need for thumbnails unless there is more than one image %>
-<% if (@product.images + @product.variant_images).uniq.size > 1 %>
+<% if @product.gallery.images.size > 1 %>
   <ul id="product-thumbnails" class="thumbnails inline" data-hook>
-    <% @product.images.each do |i| %>
+    <% @product.gallery.images.each do |i| %>
       <li class='tmb-all <%= i.variant_html_classes %>'>
         <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>
       </li>
     <% end %>
 
     <% if @product.has_variants? %>
-      <% @product.variant_images.each do |i| %>
+      <% @product.gallery.images.each do |i| %>
         <% next if @product.images.include?(i) %>
         <li class='vtmb <%= i.variant_html_classes %>'>
           <%= link_to(image_tag(i.attachment.url(:mini)), i.attachment.url(:product)) %>

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -21,14 +21,12 @@ describe Spree::Variant do
   describe 'images are ordered by variant image positions' do
     # rubocop:disable RSpec/MultipleExpectations
     it "returns the images ordered by variant image position" do
-      variant.variant_images.where(image: image_blue).first.update(position: 0)
-      variant.variant_images.where(image: image_green).first.update(position: 1)
+      variant.variant_images.where(image: image_blue).first.move_higher
       variant.images.reload
 
       expect(variant.images).to eq([image_blue, image_green])
 
-      variant.variant_images.where(image: image_blue).first.update(position: 1)
-      variant.variant_images.where(image: image_green).first.update(position: 0)
+      variant.variant_images.where(image: image_green).first.move_higher
       variant.images.reload
 
       expect(variant.images).to eq([image_green, image_blue])


### PR DESCRIPTION
The gem seems not to work out of the box with newer versions of solidus.
It does not work with the image row partial and the api, and the deface seems not to cover all occurrences of the mulriselect to be exchanged. It also does not show images in the frontend or backend overviews after being installed (does not matter if the extra assocation script is started or not).

The main problem seems to be that the distinction between images and variant images does not always make sense for the views. i did some commits to make it work.

There is one assumption i've made which should be discussed:

- The images per Product are sorted with the position of the image id. There is nothing special done with the variant_image positions. To be able to sort it we would need another view.

Also there should be some request and feature specs added. i am happy to do that. Before i would like to know if the way this goes is accepted and viable.

for solidus >2.11 compatibility it was also necessary to remove updating via the API from the images overview.