### PR TITLE
Fix ordering of variant images so the first image shows up by default

### DIFF
--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -8,7 +8,7 @@ module Spree
 
     acts_as_list
     scope :with_position, -> { where("position IS NOT NULL") }
-    default_scope -> { order("#{table_name}.position") }
+    default_scope -> { order("spree_assets.position") }
 
     # on create only just in case there are some lingering in the system
     validates :image_id, uniqueness: { scope: :variant_id, on: :create }


### PR DESCRIPTION
The default scope of variant images (`:spree_assets_variants`) does not retrieve the images in the order they are defined on the Images tab of the product so this PR is a quick fix for that by using the image (`spree_assets`) position instead of the variant image position. This might be the wrong solution to the problem though as the position of the variant image is thus ignored for the default scope.