### PR TITLE
[DRAFT] Fix image ordering and ability to update the 'alt' tag from the admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ pkg
 *.swp
 spec/dummy
 spec/examples.txt
+.vscode/settings.json

--- a/app/decorators/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/admin/images_controller_decorator.rb
@@ -7,23 +7,23 @@ module Spree
         base.before_action :set_variants, only: %i[create update]
       end
 
-      # update variant image positions the same way like image positions
-      # TODO: find more meaningful way to use variant image positions when showing images
-      def update_positions
-        ActiveRecord::Base.transaction do
-          params[:positions].each do |id, index|
-            img = Spree::Image.find(id)
-            img.set_list_position(index)
-            img.variant_images.each do |vi|
-              vi.update_attribute(:position, index)
-            end
-          end
-        end
+      # # update variant image positions the same way like image positions
+      # # TODO: find more meaningful way to use variant image positions when showing images
+      # def update_positions
+      #   ActiveRecord::Base.transaction do
+      #     params[:positions].each do |id, index|
+      #       img = Spree::Image.find(id)
+      #       img.set_list_position(index)
+      #       # img.variant_images.each do |vi|
+      #       #   vi.update_column(:position, img.position)
+      #       # end
+      #     end
+      #   end
 
-        respond_to do |format|
-          format.js { head :no_content }
-        end
-      end
+      #   respond_to do |format|
+      #     format.js { head :no_content }
+      #   end
+      # end
 
       private
 

--- a/app/decorators/controllers/spree/admin/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/admin/images_controller_decorator.rb
@@ -7,24 +7,6 @@ module Spree
         base.before_action :set_variants, only: %i[create update]
       end
 
-      # # update variant image positions the same way like image positions
-      # # TODO: find more meaningful way to use variant image positions when showing images
-      # def update_positions
-      #   ActiveRecord::Base.transaction do
-      #     params[:positions].each do |id, index|
-      #       img = Spree::Image.find(id)
-      #       img.set_list_position(index)
-      #       # img.variant_images.each do |vi|
-      #       #   vi.update_column(:position, img.position)
-      #       # end
-      #     end
-      #   end
-
-      #   respond_to do |format|
-      #     format.js { head :no_content }
-      #   end
-      # end
-
       private
 
       def set_variants

--- a/app/decorators/controllers/spree/api/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/api/images_controller_decorator.rb
@@ -14,7 +14,12 @@ module Spree
            params[:image][:viewable_ids].reject(&:blank?).present?
           @image.variant_ids = params[:image][:viewable_ids].reject(&:blank?)
         else #use master variant as falback when empty
-          @image.variant_ids = [@product.master.id]
+          # when only updating an attribute of the image (like 'alt') and not sending
+          # any viewables along, don't overwrite the existing ones
+          if @image.variant_ids.empty?
+            variant = scope.try(:master) || scope
+            @image.variant_ids = [variant.id]
+          end
         end
         # reset normal viewable
         @image.viewable_type = 'Spree::Variant'

--- a/app/decorators/models/spree/gallery/product_gallery_decorator.rb
+++ b/app/decorators/models/spree/gallery/product_gallery_decorator.rb
@@ -7,7 +7,7 @@ module Spree
 
       def self.prepended(base)
         def images
-          @images ||= @product.variant_images.collect { |vi| vi.image }.uniq
+          @images ||= Spree::Image.where(id: @product.variant_images.distinct(false).select(:image_id).group(:image_id).unscope(:order).map(&:image_id))
         end
       end
 

--- a/app/decorators/models/spree/gallery/product_gallery_decorator.rb
+++ b/app/decorators/models/spree/gallery/product_gallery_decorator.rb
@@ -7,7 +7,7 @@ module Spree
 
       def self.prepended(base)
         def images
-          @images ||= Spree::Image.where(id: @product.variant_images.distinct(false).select(:image_id).group(:image_id).unscope(:order).map(&:image_id))
+          @images ||= Spree::Image.where(id: @product.variant_images.distinct(false).select(:image_id).group(:image_id).unscope(:order).map(&:image_id)).order(:position)
         end
       end
 

--- a/app/decorators/models/spree/product_decorator.rb
+++ b/app/decorators/models/spree/product_decorator.rb
@@ -4,13 +4,12 @@ module Spree
   module ProductDecorator
     def self.prepended(base)
       base.has_many :nonuniq_variant_images,
-        -> { order(:position) },
         source: :variant_images,
         through: :variants_including_master
     end
 
     def variant_images
-      nonuniq_variant_images.reorder(:position).distinct
+      nonuniq_variant_images.distinct
     end
 
     ::Spree::Product.prepend self

--- a/app/decorators/models/spree/variant_decorator.rb
+++ b/app/decorators/models/spree/variant_decorator.rb
@@ -3,8 +3,8 @@
 module Spree
   module VariantDecorator
     def self.prepended(base)
-      base.has_many :variant_images, -> { order(:position) }, class_name: '::Spree::VariantImage'
-      base.has_many :variant_image_images, through: :variant_images, source: :image
+      base.has_many :variant_images, class_name: '::Spree::VariantImage'
+      base.has_many :variant_image_images, -> { order(:position) }, through: :variant_images, source: :image
 
       base.alias_method :images, :variant_image_images
       base.alias_method :images=, :variant_image_images=

--- a/app/models/spree/variant_image.rb
+++ b/app/models/spree/variant_image.rb
@@ -6,10 +6,6 @@ module Spree
     belongs_to :image, class_name: 'Spree::Image'
     belongs_to :variant, class_name: 'Spree::Variant', touch: true
 
-    acts_as_list
-    scope :with_position, -> { where("position IS NOT NULL") }
-    default_scope -> { order("#{table_name}.position") }
-
     # on create only just in case there are some lingering in the system
     validates :image_id, uniqueness: { scope: :variant_id, on: :create }
   end

--- a/lib/solidus_asset_variant_options/version.rb
+++ b/lib/solidus_asset_variant_options/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusAssetVariantOptions
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/spec/models/spree/variant_decorator_spec.rb
+++ b/spec/models/spree/variant_decorator_spec.rb
@@ -18,22 +18,6 @@ describe Spree::Variant do
     end
   end
 
-  describe 'images are ordered by variant image positions' do
-    # rubocop:disable RSpec/MultipleExpectations
-    it "returns the images ordered by variant image position" do
-      variant.variant_images.where(image: image_blue).first.move_higher
-      variant.images.reload
-
-      expect(variant.images).to eq([image_blue, image_green])
-
-      variant.variant_images.where(image: image_green).first.move_higher
-      variant.images.reload
-
-      expect(variant.images).to eq([image_green, image_blue])
-    end
-    # rubocop:enable RSpec/MultipleExpectations
-  end
-
   it "cannot associate itself to the same image twice" do
     expect { variant.images << image_green }.to raise_error(
       ActiveRecord::RecordInvalid,


### PR DESCRIPTION
This fixes two things:
1. Image ordering by using (again) the Image position instead of VariantImage position column (this column is now ignored and not updated anymore but have not been dropped from model)
2. The 'alt' attribute could not be updated from the admin because the product gallery needs to support CanCan's `accessible_by` and @product is not defined in the image controller on the API side (I suspect this never worked)