### PR TITLE
allow updating via api from images list

### DIFF
--- a/app/decorators/controllers/spree/api/images_controller_decorator.rb
+++ b/app/decorators/controllers/spree/api/images_controller_decorator.rb
@@ -1,15 +1,9 @@
-# frozen_string_literal: true
-
 module Spree
   module Api
     module ImagesControllerDecorator
-      def self.prepended(base)
-        base.after_action :set_variants, only: %i[create update]
-      end
 
-      private
-
-      def set_variants
+      def update
+        @image = Spree::Image.accessible_by(current_ability, :update).find(params[:id])
         if params[:image][:viewable_ids].present? &&
            params[:image][:viewable_ids].reject(&:blank?).present?
           @image.variant_ids = params[:image][:viewable_ids].reject(&:blank?)
@@ -19,6 +13,9 @@ module Spree
         # reset normal viewable
         @image.viewable_type = 'Spree::Variant'
         @image.viewable_id = @image.variant_ids.first
+
+        @image.update(image_params)
+        respond_with(@image, default_template: :show)
       end
 
       ::Spree::Api::ImagesController.prepend self

--- a/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
+++ b/app/overrides/spree/admin/images/_image_row/replace_variant_select_with_multi_select.html.erb.deface
@@ -1,4 +1,2 @@
 <!-- replace 'erb[loud]:contains("f.select :viewable_id")' -->
-<% @variants.each do |v| %>
-  <%= v[0] if image.variant_ids.include?(v[1]) %>
-<% end %>
+<%= f.select :viewable_ids, options_for_select(@variants, image.variant_ids), {}, { multiple: true, class: 'select2 fullwidth' } %>


### PR DESCRIPTION
This is a follow up to #41.

**whats actually happening:**
In the Images list of a product the assigned variants can not be updated. You first need to go to the edit screen of the image. This was a Problem since solidus 2.11, so this direct update feature was removed.

**what should happen and happens with the proposed changes**
The assigned variants can be updated again directly from the image list of a product. This is done with a change in the images_controller api decorator.
